### PR TITLE
rememberMe not always available

### DIFF
--- a/server/alexa.py
+++ b/server/alexa.py
@@ -156,7 +156,8 @@ class AlexaShoppingList:
 
     def _handle_login_password_page(self):
         self.driver.find_element(By.ID, 'ap_password').send_keys(self.password)
-        self.driver.find_element(By.NAME, 'rememberMe').click()
+        if len(self.driver.find_element(By.NAME, 'rememberMe')) > 0:
+            self.driver.find_element(By.NAME, 'rememberMe').click()
         self._login_submit_button()
     
 


### PR DESCRIPTION
For some reason, this fails for me sometimes. Probably best to check if the element exists first before trying to click on it.