### PR TITLE
Added help command and updated HASS deprecated call for loading platforms

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -138,6 +138,28 @@ class WebSocketClient:
     # ============================================================
     # Commands
 
+    async def _get_help(self):
+        help_message = """
+        Usage: [COMMAND] [ARGS]...
+
+        Commands:
+        authenticate           Authenticate with your Alexa account
+        help                   Show this help message
+        reset                  Reset the server to initial setup
+        shutdown               Send shutdown signal to server
+        quit, exit             Close the client
+        list                   List all items on your Alexa list
+        add ITEM               Add an item to your Alexa list
+        update OLD NEW         Update an item on your Alexa list
+        remove ITEM            Remove an item from your Alexa list
+        config_set KEY VALUE   Set a configuration key (e.g., "amazon_url")
+
+        Examples:
+        add cake
+        update cake "baked beans"
+        remove "baked beans"
+        """
+        print(help_message.strip())
 
     async def _cmd_config_set(self, key, value=None, announce=True):
         response = await self._send_command("config_set", key=key, value=value)
@@ -243,6 +265,9 @@ class WebSocketClient:
         if command == "authenticate":
             await self._setup_server_authentication()
         
+        if command == "help":
+            await self._get_help()
+
         if command == "reset":
             await self._cmd_reset_server()
         

--- a/custom_components/alexa_shopping_list/__init__.py
+++ b/custom_components/alexa_shopping_list/__init__.py
@@ -35,7 +35,7 @@ async def async_setup_entry(hass, entry):
     
     # hass.bus.async_listen("shopping_list_updated", alexa.homeassistant_shopping_list_updated)
     hass.data[DOMAIN][entry.entry_id] = alexa
-    await hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
 
     services = AlexaServices(alexa, _LOGGER, hass)
     hass.services.async_register(DOMAIN, SERVICE_SYNC, services.handle_sync_service)


### PR DESCRIPTION
### Changes
- Closes #60 - Added output of all available commands when typing `help` in the client.
  - Example output:
  
    ```
    Type 'help' for commands.
    
    > help
    Usage: [COMMAND] [ARGS]...
    
            Commands:
            authenticate           Authenticate with your Alexa account
            help                   Show this help message
            reset                  Reset the server to initial setup
            shutdown               Send shutdown signal to server
            quit, exit             Close the client
            list                   List all items on your Alexa list
            add ITEM               Add an item to your Alexa list
            update OLD NEW         Update an item on your Alexa list
            remove ITEM            Remove an item from your Alexa list
            config_set KEY VALUE   Set a configuration key (e.g., "amazon_url")
    
            Examples:
            add cake
            update cake "baked beans"
            remove "baked beans"
    >
    ```

- Closes #53 - Updated deprecated call (see post [Forwarding setup to config entry platforms](https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/)).
  - `hass.config_entries.async_forward_entry_setup` -> `hass.config_entries.async_forward_entry_setups` which expects an array
  - Deprecated warning does not appear in HA Core 2025.2.5 log with this change