### PR TITLE
Fix initial sync when shopping_list.json file doesn't exits and enable sync changes from HA to Alexa

### DIFF
--- a/custom_components/alexa_shopping_list/__init__.py
+++ b/custom_components/alexa_shopping_list/__init__.py
@@ -26,14 +26,15 @@ async def async_setup_entry(hass, entry):
             entry.data[CONF_PORT],
             entry.data[CONF_SYNC_MINS],
             hass.config.path(".shopping_list.json"),
-            hass.data["shopping_list"].async_load
+            hass.data["shopping_list"].async_load,
+            _LOGGER
         )
 
     except Exception as e:
         _LOGGER.error(f"Error during async_setup_entry: {e}", exc_info=True)
         return False
     
-    # hass.bus.async_listen("shopping_list_updated", alexa.homeassistant_shopping_list_updated)
+    hass.bus.async_listen("shopping_list_updated", alexa.homeassistant_shopping_list_updated)
     hass.data[DOMAIN][entry.entry_id] = alexa
     await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
 
@@ -54,7 +55,7 @@ class AlexaServices:
         self.logger.debug("Alexa Sync Service")
 
         try:
-            updated = await self.alexa.sync(self.logger, True)
+            updated = await self.alexa.sync(force=True)
             if updated == True:
                 _LOGGER.debug("Firing alexa_shopping_list_changed event")
                 self.hass.bus.async_fire("alexa_shopping_list_changed")

--- a/custom_components/alexa_shopping_list/sensor.py
+++ b/custom_components/alexa_shopping_list/sensor.py
@@ -39,7 +39,7 @@ class AlexaShoppingListSyncSensor(SensorEntity):
     async def async_update(self) -> None:
         try:
 
-            updated = await self.alexa.sync(_LOGGER)
+            updated = await self.alexa.sync()
             if updated == True:
                 _LOGGER.debug("Firing alexa_shopping_list_changed event")
                 self.hass.bus.async_fire("alexa_shopping_list_changed")


### PR DESCRIPTION
**Summary**

- When doing a fresh install, if file .shopping_list.json doesn't exists, the `sync` function never executes and because of that it never start to load Alexa shopping list:
  - Remove check in `sync` function to allow initial load and create file by `_export_ha_shopping_list`
- Completing items in HA list doesn't update Alexa:
   - Uncommented event subscription line in `__init__.py`  and added flag `_local_has_changed` in `asl.py` to only update from HA to Alexa when sensor is updated, allowing for event throttling and avoiding lists unconsistency