### PR TITLE
Fix silent failure when HA shopping list file missing

### DIFF
--- a/custom_components/alexa_shopping_list/asl.py
+++ b/custom_components/alexa_shopping_list/asl.py
@@ -185,9 +185,12 @@ class AlexaShoppingListSync:
 
 
     async def sync(self, logger=None, force=False):
+        loop = asyncio.get_running_loop()
+
         if os.path.exists(self._hasl_path) == False:
-            return False
-        
+            await self._debug_log_entry(logger, "HA shopping list file not found - creating empty list")
+            await loop.run_in_executor(None, self._export_ha_shopping_list, [])
+
         if self._cached_list_needs_updating() == False and force == False:
             return False
         
@@ -195,7 +198,6 @@ class AlexaShoppingListSync:
             return False
         self._is_syncing = True
 
-        loop = asyncio.get_running_loop()
         ha_list = await loop.run_in_executor(None, self._read_ha_shopping_list)
         original_ha_list_hash = await loop.run_in_executor(None, self._ha_shopping_list_hash)
         

--- a/server/server.py
+++ b/server/server.py
@@ -241,7 +241,7 @@ async def _process_command(websocket, path):
         response = {"result": None, "error": None}
         results = await _route_command(command, arguments)
 
-        if len(results) == 2:
+        if results is not None and len(results) == 2:
             response = {
                 "result": results[0],
                 "error": results[1]


### PR DESCRIPTION
 ## Problem

  When the HA shopping list file (`.shopping_list.json`) doesn't exist (fresh install or empty list), the `sync()` method silently returns `False` without logging or setting `last_updated`, causing `sensor.alexa_shopping_list_sync` to stay "unknown" forever.

  Additionally, `_route_command()` returning `None` crashes the server instead of returning an error.

  ## Fix

  - **asl.py**: Create an empty shopping list file instead of silently returning, allowing sync to proceed
  - **server.py**: Check for `None` before accessing `len(results)` to prevent crash

  Fixes #81 