### PR TITLE
Improve list navigation

### DIFF
--- a/server/alexa.py
+++ b/server/alexa.py
@@ -80,7 +80,7 @@ class AlexaShoppingList:
     def _clear_driver(self):
         if hasattr(self, "driver"):
             self.save_session()
-            self.driver.close()
+            self.driver.quit()
 
 
     def _selenium_wait_element(self, element: tuple):


### PR DESCRIPTION
Use selenium quit to address #82 (zombie processes).

Improve the navigation of the alexa list by changing how scrolling detects the end of the list.  Comparing objects wasn't very robust for me, so now compare the item names.

Also changed items searches by comparing item names in lowercase which should address #36 