### PR TITLE
Fix NameError exception in _do_sync

### DIFF
--- a/custom_components/alexa_shopping_list/asl.py
+++ b/custom_components/alexa_shopping_list/asl.py
@@ -185,6 +185,7 @@ class AlexaShoppingListSync:
 
 
     async def _do_sync(self, logger=None, force=False):
+        loop = asyncio.get_running_loop()
 
         ha_list = await loop.run_in_executor(None, self._read_ha_shopping_list)
         original_ha_list_hash = await loop.run_in_executor(None, self._ha_shopping_list_hash)


### PR DESCRIPTION
I'm not exactly sure why, but commit 481145d removed the definition of `loop` inside _do_sync, which now consistently causes a NameException to be thrown. I've been able to fix this by reverting the deletion and now the sensor updates fine again in my HA instance.