### PR TITLE
Fix missing local variable 'result'

### DIFF
--- a/custom_components/alexa_shopping_list/asl.py
+++ b/custom_components/alexa_shopping_list/asl.py
@@ -185,6 +185,7 @@ class AlexaShoppingListSync:
 
 
     async def _do_sync(self, logger=None, force=False):
+        loop = asyncio.get_running_loop()
 
         ha_list = await loop.run_in_executor(None, self._read_ha_shopping_list)
         original_ha_list_hash = await loop.run_in_executor(None, self._ha_shopping_list_hash)
@@ -243,6 +244,8 @@ class AlexaShoppingListSync:
         if self._is_syncing == True:
             return False
         self._is_syncing = True
+
+        result = False
 
         try:
             result = await self._do_sync(logger, force)


### PR DESCRIPTION
Fixes https://github.com/madmachinations/home-assistant-alexa-shopping-list/issues/91

I found two issues on the `asl.py` file that made the integration fail to sync HA with Alexa shopping list.

1. `result` does not exist when `_do_sync` function throws an error because it is initiated only on a successful request.
2. `loop` isn't initialized when `_do_sync` starts even though it requires the loop to get `ha_list`.