### PR TITLE
Fix NameError: pass loop to _do_sync() to fix sync on all platforms (Issue 101)

### DIFF
--- a/custom_components/alexa_shopping_list/asl.py
+++ b/custom_components/alexa_shopping_list/asl.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# PATCHED 2026-04-17: Fixed NameError in _do_sync — loop was defined in sync()
+# but not passed to _do_sync(). Added loop as first parameter to _do_sync.
+# Bug reported upstream: https://github.com/madmachinations/home-assistant-alexa-shopping-list
+# Remove this comment if/when upstream fixes and you update via HACS.
 
 import websockets
 import json
@@ -184,7 +188,7 @@ class AlexaShoppingListSync:
         logger.debug(entry)
 
 
-    async def _do_sync(self, logger=None, force=False):
+    async def _do_sync(self, loop, logger=None, force=False):
 
         ha_list = await loop.run_in_executor(None, self._read_ha_shopping_list)
         original_ha_list_hash = await loop.run_in_executor(None, self._ha_shopping_list_hash)
@@ -243,9 +247,10 @@ class AlexaShoppingListSync:
         if self._is_syncing == True:
             return False
         self._is_syncing = True
+        result = False
 
         try:
-            result = await self._do_sync(logger, force)
+            result = await self._do_sync(loop, logger, force)
         except Exception as e:
             await self._debug_log_entry(logger, type(e))
             await self._debug_log_entry(logger, e)
@@ -254,4 +259,3 @@ class AlexaShoppingListSync:
 
         return result
     # ============================================================
-


### PR DESCRIPTION
## Environment
- Integration version: 2601.005.13
- Home Assistant version: 2026.1.1 (Home Assistant Container)
- Amazon domain: amazon.com (US)
- Server: Docker container on Raspberry Pi 5 (arm64)

## Description
The integration installs and connects to the server successfully, but every sync 
attempt fails silently with an UnboundLocalError. The HA shopping list never 
populates with Alexa items.

## Error in HA logs
ERROR (MainThread) [custom_components.alexa_shopping_list.sensor]
Alexa Shopping List Sync Error: cannot access local variable 'result'
where it is not associated with a value
Traceback (most recent call last):
File "/config/custom_components/alexa_shopping_list/sensor.py", line 42, in async_update
updated = await self.alexa.sync(_LOGGER)
File "/config/custom_components/alexa_shopping_list/asl.py", line 255, in sync
return result
UnboundLocalError: cannot access local variable 'result' where it is not associated with a value

## Root Cause
In `asl.py`, `loop` is defined in `sync()` via `asyncio.get_running_loop()` but 
is referenced inside `_do_sync()` without being passed as a parameter:

```python
# In sync() — loop is defined here
async def sync(self, logger=None, force=False):
    loop = asyncio.get_running_loop()
    ...
    result = await self._do_sync(logger, force)  # loop not passed

# In _do_sync() — loop is used here but never received
async def _do_sync(self, logger=None, force=False):
    ha_list = await loop.run_in_executor(...)  # NameError: loop undefined
```

The exception is thrown inside `_do_sync()`, caught by the `except` block in 
`sync()` which only calls `_debug_log_entry()` (a no-op unless debug logging is 
enabled), and then `result` is returned before it was ever assigned — causing the 
secondary `UnboundLocalError` which is what actually surfaces in the logs.

## Fix
Pass `loop` as the first argument to `_do_sync()`:

```python
# Change _do_sync signature:
async def _do_sync(self, loop, logger=None, force=False):

# Change the call in sync():
result = await self._do_sync(loop, logger, force)
```

Fixes #101 

## Changes
- Added `loop` as first parameter to `_do_sync()`  
- Updated call site in `sync()` to pass `loop` through

Confirmed working on Raspberry Pi 5 / arm64 / amazon.com (US).