### PR TITLE
Fix Alexa shopping list sync websocket errors

### DIFF
--- a/custom_components/alexa_shopping_list/asl.py
+++ b/custom_components/alexa_shopping_list/asl.py
@@ -9,6 +9,8 @@ import hashlib
 
 # ============================================================
 
+COMMAND_TIMEOUT = 180
+
 
 class AlexaShoppingListSync:
 
@@ -24,7 +26,7 @@ class AlexaShoppingListSync:
 
 
     async def _send_command(self, command, **kwargs):
-        async with websockets.connect(self.uri) as websocket:
+        async with websockets.connect(self.uri, ping_interval=None, open_timeout=10, close_timeout=5) as websocket:
             request = {
                 'command': command,
                 'args': {
@@ -32,7 +34,12 @@ class AlexaShoppingListSync:
                 }
             }
             await websocket.send(json.dumps(request))
-            response = await websocket.recv()
+            try:
+                response = await asyncio.wait_for(websocket.recv(), timeout=COMMAND_TIMEOUT)
+            except TimeoutError as exc:
+                raise TimeoutError(
+                    f"Timed out waiting for Alexa Shopping List server response to '{command}'"
+                ) from exc
             return json.loads(response)
     
 
@@ -186,6 +193,8 @@ class AlexaShoppingListSync:
 
     async def _do_sync(self, logger=None, force=False):
 
+        loop = asyncio.get_running_loop()
+
         ha_list = await loop.run_in_executor(None, self._read_ha_shopping_list)
         original_ha_list_hash = await loop.run_in_executor(None, self._ha_shopping_list_hash)
         
@@ -245,13 +254,12 @@ class AlexaShoppingListSync:
         self._is_syncing = True
 
         try:
-            result = await self._do_sync(logger, force)
+            return await self._do_sync(logger, force)
         except Exception as e:
-            await self._debug_log_entry(logger, type(e))
-            await self._debug_log_entry(logger, e)
+            if logger != None:
+                logger.error(f"Alexa Shopping List Sync Error: {e}", exc_info=True)
+            return False
         finally:
             self._is_syncing = False
-
-        return result
     # ============================================================
 

--- a/server/alexa.py
+++ b/server/alexa.py
@@ -181,13 +181,16 @@ class AlexaShoppingList:
             # Now let's scroll back to the top
             first = None
             while True:
-                list_items = list_container.find_elements(By.CLASS_NAME, 'item-title')
-                if not list_items or first == list_items[0]:
-                    # We've reached the top
+                try:
+                    list_items = list_container.find_elements(By.CLASS_NAME, 'item-title')
+                    if not list_items or first == list_items[0]:
+                        # We've reached the top
+                        break
+                    first = list_items[0]
+                    scroll_origin = ScrollOrigin.from_element(first)
+                    ActionChains(self.driver).scroll_from_origin(scroll_origin, 0, -1000).perform()
+                except StaleElementReferenceException:
                     break
-                first = list_items[0]
-                scroll_origin = ScrollOrigin.from_element(first)
-                ActionChains(self.driver).scroll_from_origin(scroll_origin, 0, -1000).perform()
 
         return found
 

--- a/server/server.py
+++ b/server/server.py
@@ -5,6 +5,7 @@ import websockets
 import json
 import signal
 import os
+import traceback
 from alexa import AlexaShoppingList
 import time
 
@@ -230,33 +231,34 @@ async def _route_command(command, arguments={}):
 
 async def _process_command(websocket, path):
     clients.add(websocket)
-    # try:
-    async for message in websocket:
-        # try:
+    try:
+        async for message in websocket:
+            response = {"result": None, "error": None}
 
-        data = json.loads(message)
-        command = data.get('command')
-        arguments = data.get('args')
+            try:
+                data = json.loads(message)
+                command = data.get('command')
+                arguments = data.get('args')
 
-        response = {"result": None, "error": None}
-        results = await _route_command(command, arguments)
+                results = await _route_command(command, arguments)
 
-        if results is not None and len(results) == 2:
-            response = {
-                "result": results[0],
-                "error": results[1]
-            }
-        else:
-            response['error'] = 'Unknown command'
+                if results is not None and len(results) == 2:
+                    response = {
+                        "result": results[0],
+                        "error": results[1]
+                    }
+                else:
+                    response['error'] = 'Unknown command'
 
-        # except json.JSONDecodeError:
-        #     response = {'error': 'Invalid JSON'}
-        # except:
-        #     response = {'error': 'Fatal exception'}
+            except json.JSONDecodeError:
+                response['error'] = 'Invalid JSON'
+            except Exception as e:
+                traceback.print_exc()
+                response['error'] = str(e)
 
-        await websocket.send(json.dumps(response))
-    # finally:
-    clients.remove(websocket)
+            await websocket.send(json.dumps(response))
+    finally:
+        clients.remove(websocket)
 
 # ============================================================
 # Start/Stop


### PR DESCRIPTION
## Summary
- fix Home Assistant sync returning an undefined `result` when sync fails before assignment
- disable websocket keepalive pings on the HA client and add an explicit 180-second command timeout for slow Alexa/Selenium operations
- prevent the add-on server from tearing down the websocket on command exceptions
- handle Selenium stale element errors while scrolling back to the top after list updates

## Validation
Confirmed working on a live Home Assistant install as of April 20, 2026.

Validated with:
- `python -m py_compile custom_components/alexa_shopping_list/asl.py server/server.py server/alexa.py`
- direct websocket `get_list` test against the Alexa Shopping List add-on
- direct websocket add/remove test using a temporary item
- `hass-cli.exe --timeout 240 service call alexa_shopping_list.sync_alexa_shopping_list`

The forced Home Assistant service sync completed successfully and returned `[]`. After the patched integration and add-on server were loaded, no new `custom_components.alexa_shopping_list` errors appeared in the Home Assistant or add-on logs.

## Notes
The live issue originally surfaced as `UnboundLocalError: cannot access local variable 'result'`, but after fixing that, the underlying failures were websocket keepalive timeouts and a Selenium `StaleElementReferenceException` during `add_item`.