### PR TITLE
Fix: sync always fails due to undefined `loop` in `_do_sync`

### DIFF
--- a/custom_components/alexa_shopping_list/asl.py
+++ b/custom_components/alexa_shopping_list/asl.py
@@ -6,6 +6,9 @@ import datetime
 import os
 import asyncio
 import hashlib
+import logging
+
+_LOGGER = logging.getLogger(__name__)
 
 # ============================================================
 
@@ -185,6 +188,7 @@ class AlexaShoppingListSync:
 
 
     async def _do_sync(self, logger=None, force=False):
+        loop = asyncio.get_running_loop()
 
         ha_list = await loop.run_in_executor(None, self._read_ha_shopping_list)
         original_ha_list_hash = await loop.run_in_executor(None, self._ha_shopping_list_hash)
@@ -244,9 +248,11 @@ class AlexaShoppingListSync:
             return False
         self._is_syncing = True
 
+        result = False
         try:
             result = await self._do_sync(logger, force)
         except Exception as e:
+            _LOGGER.error("Alexa Shopping List sync failed: %s", e)
             await self._debug_log_entry(logger, type(e))
             await self._debug_log_entry(logger, e)
         finally:


### PR DESCRIPTION
@
## The bug

Every sync fails and the shopping list never populates in Home Assistant. The error surfaced in the logs is:

```
Alexa Shopping List Sync Error: cannot access local variable 'result' where it is not associated with a value
```

## Root cause

In `asl.py`, `_do_sync()` uses a variable `loop` (e.g. `await loop.run_in_executor(None, self._read_ha_shopping_list)`), but `loop` is only defined in `sync()`, not in `_do_sync()`. So `_do_sync()` raises `NameError: name 'loop' is not defined` on its very first line.

That exception is caught in `sync()`, but only logged via `_debug_log_entry` (debug level, normally invisible). Because the `try` failed, `result` is never assigned, so the subsequent `return result` raises the `UnboundLocalError` that users actually see — masking the real cause.

Net effect: the To Do / shopping list sync can never succeed on a fresh install.

## The fix

- Define `loop = asyncio.get_running_loop()` at the top of `_do_sync()`.
- Initialise `result = False` before the `try` in `sync()` so a failure can no longer raise `UnboundLocalError`.
- Log the real exception via `_LOGGER.error(...)` so future failures are visible without enabling debug.

Diagnosed against a live Home Assistant install: after this change the Alexa shopping list syncs correctly into `todo`/`shopping_list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@